### PR TITLE
Improve Mongo query efficiency

### DIFF
--- a/Decision.js
+++ b/Decision.js
@@ -6,4 +6,6 @@ const DecisionSchema = new mongoose.Schema({
   decision: { type: Object, required: true },
   createdAt: { type: Date, default: Date.now, index: true }
 }, { versionKey: false, minimize: true });
+
+DecisionSchema.index({ threadId: 1, createdAt: -1 });
 export const Decision = mongoose.models.Decision || mongoose.model('Decision', DecisionSchema);

--- a/server.js
+++ b/server.js
@@ -62,6 +62,7 @@ const MessageSchema = new mongoose.Schema({
 }, { versionKey: false, minimize: true });
 
 MessageSchema.index({ threadId: 1, createdAt: 1 });
+MessageSchema.index({ threadId: 1, createdAt: -1 });
 const Message = mongoose.model('Message', MessageSchema);
 
 function calcExpiresAt() {
@@ -71,18 +72,27 @@ function calcExpiresAt() {
 }
 
 async function buildContext(threadId) {
-  const rows = await Message.find({ threadId }).sort({ createdAt: -1 }).limit(MAX_MESSAGES).lean();
-  const chrono = rows.slice().reverse();
+  const rows = await Message.find({ threadId })
+    .sort({ createdAt: -1 })
+    .limit(MAX_MESSAGES)
+    .select({ role: 1, content: 1, createdAt: 1 })
+    .lean();
+
+  if (!rows.length) return [];
+
   let total = 0;
-  const chosen = [];
-  for (let i = chrono.length - 1; i >= 0; i--) {
-    const msg = chrono[i];
+  const withinLimit = [];
+
+  for (const msg of rows) {
     const len = (msg.content || '').length;
     if (total + len > MAX_CHARS) break;
     total += len;
-    chosen.unshift(msg);
+    withinLimit.push(msg);
   }
-  return chosen.length ? chosen : chrono;
+
+  const base = withinLimit.length ? withinLimit : rows;
+  base.reverse();
+  return base;
 }
 
 async function insertMessage({ threadId, role, content, externalId }) {
@@ -119,8 +129,12 @@ app.post('/messages', requireAuth, async (req, res) => {
 
 app.get('/threads/:threadId', requireAuth, async (req, res) => {
   const { threadId } = req.params;
-  const messages = await Message.find({ threadId }).sort({ createdAt: 1 }).lean();
-  res.json({ threadId, messages });
+  const messages = await Message.find({ threadId })
+    .sort({ createdAt: -1 })
+    .select({ role: 1, content: 1, createdAt: 1, externalId: 1 })
+    .lean();
+  const ordered = messages.length ? [...messages].reverse() : [];
+  res.json({ threadId, messages: ordered });
 });
 
 app.post('/reply', requireAuth, async (req, res) => {


### PR DESCRIPTION
## Summary
- add a descending compound index for message lookups and trim the context query to only fetch required fields
- optimize thread retrieval to rely on the new index and avoid returning unused payload
- add a compound index to the decisions collection to keep per-thread lookups from requiring in-memory sorts

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68df14eccfa8832dad979d7333ab8e0b